### PR TITLE
Now supporting adding a manga via url

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -33,7 +33,7 @@ library, downloading certain chapters of your manga, etc.
 func init() {
 	rootCmd.AddCommand(addCmd)
 	addCmd.Flags().String("provider", "", "[mangakakalot]")
-	addCmd.Flags().String("dlmode", "", "[dynamic, all, none]")
+	addCmd.Flags().StringP("dlmode", "d", "", "[dynamic, all, none]")
 	addCmd.Flags().StringP("url", "u", "", "add by url")
 }
 
@@ -90,6 +90,11 @@ func parseDlmode(dlmodeFlag string) (dlmode string) {
 func Add(url string, dlmode string, provider string, name string) {
 	if len(url) > 0 {
 		AddFromUrl(dlmode, url)
+		return
+	}
+
+	if len(name) > 0 {
+		AddFromQuery(provider, dlmode, name)
 		return
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,11 +21,12 @@ perform actions on it like editing saved information, removing it from your
 library, downloading certain chapters of your manga, etc.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		providerType, _ := cmd.Flags().GetString("provider")
+		url, _ := cmd.Flags().GetString("url")
 		dlmode, _ := cmd.Flags().GetString("dlmode")
+		provider, _ := cmd.Flags().GetString("provider")
 		name := strings.Join(args, " ")
 
-		Add(providerType, dlmode, name)
+		Add(url, dlmode, provider, name)
 	},
 }
 
@@ -33,9 +34,97 @@ func init() {
 	rootCmd.AddCommand(addCmd)
 	addCmd.Flags().String("provider", "", "[mangakakalot]")
 	addCmd.Flags().String("dlmode", "", "[dynamic, all, none]")
+	addCmd.Flags().StringP("url", "u", "", "add by url")
 }
 
-func Add(providerType string, dlmode string, name string) {
+func addMode() (selection string) {
+	addMode := &survey.Select{
+		Message: "How would you like to add a manga?",
+		Options: []string{"Search", "Url"},
+	}
+
+	err := survey.AskOne(addMode, &selection, survey.WithValidator(survey.Required))
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
+// This exact function was used in both the AddFromQuery
+// and AddFromUrl functions so it was broken out for reuse.
+func parseDlmode(dlmodeFlag string) (dlmode string) {
+	if len(dlmodeFlag) == 0 {
+		question := &survey.Select{
+			Message: "Download Mode:",
+			Options: []string{
+				"Dynamic: download as you read",
+				"All: download all chapters now",
+				"None: don't download any chapters"},
+			Default: "Dynamic: download as you read",
+		}
+
+		var selection string
+		err := survey.AskOne(question, &selection, survey.WithValidator(survey.Required))
+		if err != nil {
+			panic(err)
+		}
+
+		if strings.Contains(selection, "All") {
+			dlmode = "all"
+		} else if strings.Contains(selection, "Dynamic") {
+			dlmode = "dynamic"
+		} else if strings.Contains(selection, "None") {
+			dlmode = "none"
+		} else {
+			panic("invalid download mode")
+		}
+	} else {
+		dlmode = dlmodeFlag
+	}
+	return
+}
+
+// Parent Add function. This is necessary to support the direct
+// invocation of the add function as well as supporting the
+// pathway through the interactive interface.
+func Add(url string, dlmode string, provider string, name string) {
+	if len(url) > 0 {
+		AddFromUrl(dlmode, url)
+		return
+	}
+
+	var mode = addMode()
+
+	switch {
+	case strings.Contains(mode, "Url"):
+		AddFromUrl(dlmode, url)
+	case strings.Contains(mode, "Search"):
+		AddFromQuery(provider, dlmode, name)
+	}
+}
+
+// The AddFromUrl function does not require a name or provider
+// parameter so it was broken out to be more explicit.
+func AddFromUrl(dlmode string, url string) {
+	if len(url) == 0 {
+		question := &survey.Input{
+			Message: "Enter the url",
+		}
+
+		err := survey.AskOne(question, &url, survey.WithValidator(survey.Required))
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	dlmode = parseDlmode(dlmode)
+
+	kocha.AddFromUrl(url, dlmode)
+}
+
+// Ask the user for a provider, download mode, and name for a manga
+// and then add it to the database.
+func AddFromQuery(providerType string, dlmode string, name string) {
 	if len(name) == 0 {
 		question := &survey.Input{
 			Message: "What manga do you want to add?",
@@ -63,32 +152,7 @@ func Add(providerType string, dlmode string, name string) {
 		providerType = strings.ToLower(selection)
 	}
 
-	if len(dlmode) == 0 {
-		question := &survey.Select{
-			Message: "Download Mode:",
-			Options: []string{
-				"Dynamic: download as you read",
-				"All: download all chapters now",
-				"None: don't download any chapters"},
-			Default: "Dynamic: download as you read",
-		}
-
-		var selection string
-		err := survey.AskOne(question, &selection, survey.WithValidator(survey.Required))
-		if err != nil {
-			panic(err)
-		}
-
-		if strings.Contains(selection, "All") {
-			dlmode = "all"
-		} else if strings.Contains(selection, "Dynamic") {
-			dlmode = "dynamic"
-		} else if strings.Contains(selection, "None") {
-			dlmode = "none"
-		} else {
-			panic("invalid download mode")
-		}
-	}
+	dlmode = parseDlmode(dlmode)
 
 	var page uint64 = 1
 	searchResults := kocha.Search(name, providerType, page)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -45,6 +45,11 @@ func init() {
 func Read() {
 	manga := kocha.List()
 
+	if len(manga) == 0 {
+		fmt.Println("Please add a manga first!")
+		os.Exit(1)
+	}
+
 	var options []string
 	items := make(map[string]models.Manga)
 	for _, m := range manga {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ var rootCmd = &cobra.Command{
 			if selection == "Quit" {
 				break
 			} else if selection == "Add" {
-				Add("", "", "")
+				Add("", "", "", "")
 			} else if selection == "List" {
 				List()
 			} else if selection == "Remove" {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 
 require (
 	github.com/andybalholm/cascadia v1.2.0 // indirect
+	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=

--- a/internal/models/chapter.go
+++ b/internal/models/chapter.go
@@ -14,6 +14,10 @@ type Chapter struct {
 	// Manga   Manga
 }
 
+func (Chapter) TableName() string {
+	return "chapters"
+}
+
 func init() {
 	db, cancel := util.Database()
 	defer cancel()

--- a/internal/models/common.go
+++ b/internal/models/common.go
@@ -1,0 +1,5 @@
+package models
+
+type Tabler interface {
+	TableName() string
+}

--- a/internal/models/manga.go
+++ b/internal/models/manga.go
@@ -21,6 +21,10 @@ type Manga struct {
 	//Chapters       []Chapter
 }
 
+func (Manga) TableName() string {
+	return "manga"
+}
+
 func init() {
 	db, cancel := util.Database()
 	defer cancel()

--- a/internal/providers/mangakakalot.go
+++ b/internal/providers/mangakakalot.go
@@ -3,7 +3,6 @@ package providers
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -21,23 +20,13 @@ type MangaKakalot struct{}
 func (m MangaKakalot) Search(name string, page uint64) (SearchResult, error) {
 	var result SearchResult
 
-	res, err := http.Get(fmt.Sprintf("https://ww.mangakakalot.tv/search/%s?page=%d", name, page))
-	if err != nil {
-		return result, err
-	}
-
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return result, errors.New("mangakakalot search failed")
-	}
-
-	doc, err := goquery.NewDocumentFromReader(res.Body)
+	doc, err := FetchDocument(fmt.Sprintf("https://ww.mangakakalot.tv/search/%s?page=%d", name, page))
 	if err != nil {
 		fmt.Println(err)
 		return result, errors.New("mangakakalot search failed")
 	}
 
+	var parseError error
 	doc.Find("div.story_item").Each(func(i int, s *goquery.Selection) {
 		// For each item found, get the title
 		var manga models.Manga
@@ -77,13 +66,18 @@ func (m MangaKakalot) Search(name string, page uint64) (SearchResult, error) {
 
 		update_time, err := time.Parse(fmt.Sprintf("02 Jan 2006 15:04 %s", time_suffix), fmt.Sprintf("%s %s %s", date, year, time_string))
 		if err != nil {
-			fmt.Println(err)
+			parseError = err
 			return
 		}
 		manga.Updated = update_time
 
 		result.Manga = append(result.Manga, manga)
 	})
+
+	if parseError != nil {
+		fmt.Println(parseError)
+		return result, errors.New("Failed to parse manga")
+	}
 
 	r1 := regexp.MustCompile(`[0-9]+`)
 	total_pages, err := strconv.ParseUint(r1.FindString(doc.Find("a.page_last").Text()), 10, 64)
@@ -100,21 +94,7 @@ func (m MangaKakalot) Search(name string, page uint64) (SearchResult, error) {
 }
 
 func (mangakakalot MangaKakalot) DownloadChapter(chapter models.Chapter, completed chan bool) {
-	res, err := http.Get(chapter.Uri)
-	if err != nil {
-		fmt.Println(err)
-		completed <- false
-		return
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		fmt.Println("downloading chapter failed")
-		completed <- false
-		return
-	}
-
-	doc, err := goquery.NewDocumentFromReader(res.Body)
+	doc, err := FetchDocument(chapter.Uri)
 	if err != nil {
 		fmt.Println(err)
 		completed <- false
@@ -141,19 +121,9 @@ func (mangakakalot MangaKakalot) DownloadChapter(chapter models.Chapter, complet
 	}
 }
 
+// Download chapters of a manga according to the download mode
 func (mangakakalot MangaKakalot) DownloadManga(manga *models.Manga) error {
-	res, err := http.Get(manga.Uri)
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return errors.New("mangakakalot search failed")
-	}
-
-	doc, err := goquery.NewDocumentFromReader(res.Body)
+	doc, err := FetchDocument(manga.Uri)
 	if err != nil {
 		fmt.Println(err)
 		return errors.New("mangakakalot search failed")
@@ -210,4 +180,55 @@ func (mangakakalot MangaKakalot) DownloadManga(manga *models.Manga) error {
 
 	}
 	return nil
+}
+
+// Get a manga from a provided URL
+func (m MangaKakalot) GetManga(url string, dlmode string) (models.Manga, error) {
+	var manga models.Manga
+
+	doc, err := FetchDocument(url)
+	if err != nil {
+		fmt.Println(err)
+		return manga, errors.New("mangakakalot search failed")
+	}
+
+	var parseError error
+	doc.Find("ul.manga-info-text").Each(func(i int, s *goquery.Selection) {
+		manga.Provider = "mangakakalot"
+		manga.Title = s.Find("li > h1").Text()
+		manga.Uri = url
+		manga.Dlmode = dlmode
+
+		authors := []string{}
+		first_child := s.Children().Nodes[1].FirstChild
+		last_child := s.Children().Nodes[1].LastChild
+		position := first_child.NextSibling
+		for position != last_child {
+			if position.Type == 3 {
+				authors = append(authors, position.FirstChild.Data)
+			}
+			position = position.NextSibling
+		}
+		manga.Authors = strings.Join(authors, ",")
+
+		raw_time := strings.Trim(strings.SplitN(s.Children().Nodes[3].FirstChild.Data, ":", 2)[1], " ")
+		date_string := raw_time[:strings.Index(raw_time, "-")-1]
+		date_string = strings.ReplaceAll(date_string, ",", " ")
+		time_string := raw_time[strings.Index(raw_time, "-")+1:]
+		parsed_time := strings.SplitN(time_string, " ", -1)
+		time_suffix := parsed_time[len(parsed_time)-1]
+		update_time, err := time.Parse(fmt.Sprintf("Jan 02 2006 15:04 %s", time_suffix), fmt.Sprintf("%s %s", date_string, time_string))
+		if err != nil {
+			parseError = err
+			return
+		}
+		manga.Updated = update_time
+	})
+
+	if parseError != nil {
+		fmt.Println(parseError)
+		return manga, errors.New("Failed to parse manga")
+	}
+
+	return manga, nil
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -13,7 +13,7 @@ import (
 type Provider interface {
 	Search(name string, page uint64) (SearchResult, error)
 	DownloadManga(manga *models.Manga) error
-	DownloadChapter(chapter models.Chapter, completed chan bool)
+	DownloadChapter(chapter models.Chapter)
 	GetManga(url string, dlmode string) (models.Manga, error)
 }
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -2,7 +2,11 @@ package providers
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/tkmcclellan/kocha/internal/models"
 )
 
@@ -10,6 +14,7 @@ type Provider interface {
 	Search(name string, page uint64) (SearchResult, error)
 	DownloadManga(manga *models.Manga) error
 	DownloadChapter(chapter models.Chapter, completed chan bool)
+	GetManga(url string, dlmode string) (models.Manga, error)
 }
 
 type SearchResult struct {
@@ -26,4 +31,40 @@ func FindProvider(provider string) (Provider, error) {
 	default:
 		return nil, errors.New("invalid provider")
 	}
+}
+
+// Return a supported provider from a given URL. This could
+// possibly be done better but this was the first solution
+// I came up with
+func FindProviderFromUrl(url string) (Provider, error) {
+	switch {
+	case strings.HasPrefix(url, "https://ww1.mangakakalot.tv"), strings.HasPrefix(url, "http://ww1.mangakakalot.tv"):
+		fallthrough
+	case strings.HasPrefix(url, "https://ww.mangakakalot.tv"), strings.HasPrefix(url, "http://ww.mangakakalot.tv"):
+		m := MangaKakalot{}
+		return m, nil
+	default:
+		return nil, errors.New("invalid provider")
+	}
+}
+
+// General function to query a document from a given URL
+func FetchDocument(url string) (document *goquery.Document, err error) {
+	res, err := http.Get(url)
+	if err != nil {
+		return document, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return document, errors.New("Failed to fetch document")
+	}
+
+	document, err = goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		fmt.Println(err)
+		return document, errors.New("Failed to parse document")
+	}
+	return document, err
 }

--- a/pkg/kocha/add.go
+++ b/pkg/kocha/add.go
@@ -28,3 +28,27 @@ func Add(manga *models.Manga, dlmode string) error {
 
 	return nil
 }
+
+func AddFromUrl(url string, dlmode string) error {
+	provider, err := providers.FindProviderFromUrl(url)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	manga, err := provider.GetManga(url, dlmode)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	manga.Create()
+
+	err = provider.DownloadManga(&manga)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR includes some general cleanup of the Mangakaklot provider code as well as adding support for adding manga via url. The add command now includes a flag to add via url which is -u and --url but the default behavior remains search.